### PR TITLE
Automatically Generate License Reports

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 # Install omnibus
-gem 'omnibus', :github => 'krallin/omnibus', :ref => 'b82199c533f78f6e795917d39113fdc664c945f8'
+gem 'omnibus', :github => 'krallin/omnibus', :ref => '3b91d45'
 
 # Use Chef's software definitions. It is recommended that you write your own
 # software definitions, but you can clone/fork Chef's to get you started.

--- a/build/shared/build.sh
+++ b/build/shared/build.sh
@@ -6,6 +6,7 @@ set -o pipefail
 GIT_CACHE_PATH="${OMNIBUS_BASE_DIR}/cache/git_cache/opt/scalr-server"
 GIT_BUNDLE_PATH="${OMNIBUS_PACKAGE_DIR}/git_cache.bundle"
 
+: ${OMNIBUS_NO_BUNDLE:="0"}
 : ${OMNIBUS_LOG_LEVEL:="info"}
 
 # Prepare git config
@@ -13,19 +14,23 @@ git config --global user.email "builder@scalr.com"
 git config --global user.name "Scalr Builder"
 
 # Do we have a bundle to restore?
-if [ -f "${GIT_BUNDLE_PATH}" ]; then
-  echo "Restoring '${GIT_BUNDLE_PATH}' to '${GIT_CACHE_PATH}'"
+if [ ! "${OMNIBUS_NO_BUNDLE}" -eq 1 ]; then
+  if [ -f "${GIT_BUNDLE_PATH}" ]; then
+    echo "Restoring '${GIT_BUNDLE_PATH}' to '${GIT_CACHE_PATH}'"
 
-  # Remove anything that might have existed before.
-  mkdir --parents "${GIT_CACHE_PATH}"
-  rm -rf "${GIT_CACHE_PATH}"
-  git clone --mirror "${GIT_BUNDLE_PATH}" "${GIT_CACHE_PATH}" || {
-    echo "WARNING: Unable to restore! ($?)"
-  }
+    # Remove anything that might have existed before.
+    mkdir --parents "${GIT_CACHE_PATH}"
+    rm -rf "${GIT_CACHE_PATH}"
+    git clone --mirror "${GIT_BUNDLE_PATH}" "${GIT_CACHE_PATH}" || {
+      echo "WARNING: Unable to restore! ($?)"
+    }
+  else
+    echo "No bundle to restore from (expected '${GIT_BUNDLE_PATH}')"
+    echo "NOTE: a bundle might exist at '${GIT_CACHE_PATH}'"
+    echo "      Omnibus will attempt to use it if present."
+  fi
 else
-  echo "No bundle to restore from (expected '${GIT_BUNDLE_PATH}')"
-  echo "NOTE: a bundle might exist at '${GIT_CACHE_PATH}'"
-  echo "      Omnibus will attempt to use it if present."
+  echo "Bundle caching is DISABLED -- Not restoring"
 fi
 
 # Cleanup old scalr-app src. This is needed because Omnibus does not properly
@@ -54,10 +59,14 @@ ret=$?
 set -o errexit
 
 # Trim the bundle
-/optimize_repo.py "${GIT_CACHE_PATH}"
+if [ ! "${OMNIBUS_NO_BUNDLE}" -eq 1 ]; then
+  /optimize_repo.py "${GIT_CACHE_PATH}"
 
-# Back up the bundle
-echo "Backing up '${GIT_CACHE_PATH}' to '${GIT_BUNDLE_PATH}'"
-git --git-dir="${GIT_CACHE_PATH}" bundle create "${GIT_BUNDLE_PATH}" --tags
+  # Back up the bundle
+  echo "Backing up '${GIT_CACHE_PATH}' to '${GIT_BUNDLE_PATH}'"
+  git --git-dir="${GIT_CACHE_PATH}" bundle create "${GIT_BUNDLE_PATH}" --tags
+else
+  echo "Bundle caching is DISABLED -- Not backing up"
+fi
 
 exit ${ret}

--- a/config/software/apr-util.rb
+++ b/config/software/apr-util.rb
@@ -4,12 +4,14 @@ default_version '1.5.4'
 source url: "http://www.us.apache.org/dist/apr/apr-util-#{version}.tar.bz2",
        md5: '2202b18f269ad606d70e1864857ed93c'
 
-relative_path "apr-util-#{version}"
-
 dependency 'apr'
 dependency 'gdbm'
 dependency 'openssl'
 dependency 'sqlite'
+
+relative_path "apr-util-#{version}"
+
+license path: 'LICENSE'
 
 
 build do

--- a/config/software/apr.rb
+++ b/config/software/apr.rb
@@ -6,6 +6,8 @@ source url: "http://www.us.apache.org/dist/apr/apr-#{version}.tar.bz2",
 
 relative_path "apr-#{version}"
 
+license path: 'LICENSE'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -28,6 +28,9 @@ source url: "http://www.bzip.org/#{version}/#{name}-#{version}.tar.gz",
 
 relative_path "#{name}-#{version}"
 
+license path: 'LICENSE'
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/cairo.rb
+++ b/config/software/cairo.rb
@@ -4,14 +4,15 @@ default_version '1.12.18'
 source url: "http://cairographics.org/releases/cairo-#{version}.tar.xz",
        md5: '8e4ff32b82c3b39387eb6f5c59ef848e'
 
-relative_path "cairo-#{version}"
-
-
 dependency 'pixman'
 dependency 'libpng'
 dependency 'zlib'
 dependency 'freetype_pre'  # We can't use 'freetype' here because 'harfbuzz' depends on 'cairo' and 'freetype' depends on 'harfbuzz'.
 dependency 'fontconfig'
+
+relative_path "cairo-#{version}"
+
+license path: 'COPYING-MPL-1.1'
 
 
 build do

--- a/config/software/chef-gem.rb
+++ b/config/software/chef-gem.rb
@@ -23,6 +23,9 @@ dependency 'ruby'
 dependency 'rubygems'
 dependency 'libffi'
 
+license url: "https://raw.githubusercontent.com/chef/chef/#{version}/LICENSE"
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -35,6 +35,9 @@ end
 
 relative_path "curl-#{version}"
 
+license path: 'COPYING'
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/dcron.rb
+++ b/config/software/dcron.rb
@@ -6,6 +6,9 @@ source url: "http://www.jimpryor.net/linux/releases/dcron-#{version}.tar.gz",
 
 relative_path "#{name}-#{version}"
 
+license url: 'https://www.gnu.org/licenses/gpl-3.0.txt'
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/dejavu-sans-ttf.rb
+++ b/config/software/dejavu-sans-ttf.rb
@@ -3,11 +3,14 @@ default_version '2.34'
 
 source url: "http://sourceforge.net/projects/dejavu/files/dejavu/#{version}/dejavu-sans-ttf-#{version}.zip"
 
-relative_path "dejavu-sans-ttf-#{version}"
-
 version '2.34' do
   source md5: 'cdcd347d8c13934dd52a777ced41020a'
 end
+
+relative_path "dejavu-sans-ttf-#{version}"
+
+license path: 'LICENSE'
+
 
 build do
   font_dir = "#{install_dir}/embedded/share/fonts/truetype/dejavu"

--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2014 Chef Software, Inc.
 # Copyright 2015 Scalr, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,28 +15,26 @@
 # limitations under the License.
 #
 
-name 'libzmq'
-default_version '4.0.5'
+name "expat"
+default_version "2.1.0"
 
-dependency 'libuuid'
+source url: "http://downloads.sourceforge.net/project/expat/expat/#{version}/expat-#{version}.tar.gz"
 
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
-
-version '4.0.5' do
-  source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d'
+version '2.1.0' do
+  source md5: "dd7dab7a5fea97d2a6a43f511449b7cd"
 end
 
-relative_path "zeromq-#{version}"
+relative_path "expat-#{version}"
 
-license path: 'COPYING.LESSER'
+license path: 'COPYING'
 
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['CXXFLAGS'] = "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 
-  command "./configure --prefix=#{install_dir}/embedded", env: env
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  make "install", env: env
 end

--- a/config/software/file.rb
+++ b/config/software/file.rb
@@ -6,6 +6,9 @@ source url: "ftp://ftp.astron.com/pub/file/file-#{version}.tar.gz",
 
 relative_path "file-#{version}"
 
+license path: 'COPYING'
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/finalize.rb
+++ b/config/software/finalize.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# NOLICENSE (Nothing included in package)
+
 name 'finalize'
 description 'Cleans up useless data, generates a version manifest file and license manifest files'
 default_version '2.0.0'

--- a/config/software/finalize.rb
+++ b/config/software/finalize.rb
@@ -16,10 +16,18 @@
 #
 
 name 'finalize'
-description 'Cleans up useless data, and generates a version manifest file'
-default_version '1.0.0'
+description 'Cleans up useless data, generates a version manifest file and license manifest files'
+default_version '2.0.0'
+
+source :path => File.expand_path('files/license-scripts', Omnibus::Config.project_root)
+
+dependency 'yolk'
+dependency 'license-gem'
+
 
 build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
   # Cleanup irrelevant data
 
   # noinspection RubyLiteralArrayInspection
@@ -40,12 +48,31 @@ build do
     command "rm -rf '#{install_dir}/embedded/#{dir}'"
   end
 
-  # Manifest
+  # Version Manifest
   block do
-    File.open("#{install_dir}/version-manifest.txt", "w") do |f|
+    File.open("#{install_dir}/version-manifest.txt", 'w') do |f|
       f.puts "#{project.name} #{project.build_version}"
       f.puts ''
       f.puts Omnibus::Reports.pretty_version_map(project)
     end
   end
+
+  # License manifest
+  license_dir = "#{install_dir}/embedded/LICENSES"
+  mkdir license_dir
+
+  block do
+    File.open("#{license_dir}/license-manifest.txt", 'w') do |f|
+      f.puts Omnibus::Reports.pretty_license_file(project)
+    end
+  end
+
+  command "#{install_dir}/embedded/bin/python" \
+          ' ./python-licenses.py' \
+          " #{license_dir}/python-lib-licenses.txt", env: env
+
+  command "#{install_dir}/embedded/bin/ruby" \
+          ' ./ruby-licenses.rb' \
+          " #{license_dir}/ruby-lib-licenses.txt", env: env
+
 end

--- a/config/software/fontconfig.rb
+++ b/config/software/fontconfig.rb
@@ -10,6 +10,8 @@ relative_path "fontconfig-#{version}"
 dependency 'libiconv'
 dependency 'expat'
 
+license path: 'COPYING'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/freetype.rb
+++ b/config/software/freetype.rb
@@ -5,13 +5,15 @@ default_version '2.5.5'
 source url: "http://download.savannah.gnu.org/releases/freetype/freetype-#{version}.tar.bz2",
        md5: '2a7a314927011d5030903179cf183be0'
 
-relative_path "freetype-#{version}"
-
-
 dependency 'libpng'
 dependency 'bzip2'
 dependency 'zlib'
 dependency 'harfbuzz'
+
+relative_path "freetype-#{version}"
+
+license path: 'docs/FTL.TXT', encoding: Encoding::ISO_8859_1
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/freetype_pre.rb
+++ b/config/software/freetype_pre.rb
@@ -1,4 +1,7 @@
 # This is needed as a workaround because there is a circular dependency between freetype and harfbuzz.
+
+# NOLICENSE (freetype is the one included)
+
 name 'freetype_pre'
 default_version '2.5.5'
 

--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -15,28 +15,34 @@
 # limitations under the License.
 #
 
-name 'libzmq'
-default_version '4.0.5'
+name "gdbm"
+default_version "1.9.1"
 
-dependency 'libuuid'
+source url: "http://ftp.gnu.org/gnu/gdbm/gdbm-#{version}.tar.gz"
 
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
-
-version '4.0.5' do
-  source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d'
+version '1.9.1' do
+  source md5: "59f6e4c4193cb875964ffbe8aa384b58"
 end
 
-relative_path "zeromq-#{version}"
+relative_path "gdbm-#{version}"
 
-license path: 'COPYING.LESSER'
+license path: 'COPYING'
 
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['CXXFLAGS'] = "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 
-  command "./configure --prefix=#{install_dir}/embedded", env: env
+  if freebsd?
+    command "./configure" \
+            " --enable-libgdbm-compat" \
+            " --with-pic" \
+            " --prefix=#{install_dir}/embedded", env: env
+  else
+    command "./configure" \
+            " --enable-libgdbm-compat" \
+            " --prefix=#{install_dir}/embedded", env: env
+  end
 
   make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  make "install", env: env
 end

--- a/config/software/gettext.rb
+++ b/config/software/gettext.rb
@@ -4,14 +4,15 @@ default_version '0.18.3.1'
 source url: "http://archive.ubuntu.com/ubuntu/pool/main/g/gettext/gettext_#{version}.orig.tar.gz",
        md5: '3fc808f7d25487fc72b5759df7419e02'
 
-relative_path "gettext-#{version}"
-
 dependency 'libiconv'
 dependency 'ncurses'
 dependency 'expat'
 dependency 'libxml2'
 
-# TODO - Can we somehow guarantee openmp presence?
+relative_path "gettext-#{version}"
+
+license path: 'COPYING'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/glib.rb
+++ b/config/software/glib.rb
@@ -4,12 +4,14 @@ default_version '2.42.1'
 source url: "http://ftp.gnome.org/pub/gnome/sources/glib/2.42/glib-#{version}.tar.xz",
        md5: '89c4119e50e767d3532158605ee9121a'
 
-relative_path "glib-#{version}"
-
 # See: https://developer.gnome.org/glib/2.42/glib-building.html
 dependency 'libiconv'
 dependency 'gettext'
 dependency 'libffi'
+
+relative_path "glib-#{version}"
+
+license path: 'COPYING'
 
 
 build do

--- a/config/software/harfbuzz.rb
+++ b/config/software/harfbuzz.rb
@@ -1,15 +1,20 @@
 name 'harfbuzz'
 default_version '0.9.37'
 
-source url: "http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-#{version}.tar.bz2",
-       md5: 'bfe733250e34629a188d82e3b971bc1e'
+source url: "http://www.freedesktop.org/software/harfbuzz/release/harfbuzz-#{version}.tar.bz2"
 
-relative_path "harfbuzz-#{version}"
-
+version '0.9.37' do
+  source md5: 'bfe733250e34629a188d82e3b971bc1e'
+end
 
 dependency 'glib'
 dependency 'freetype_pre'
 dependency 'cairo'
+
+relative_path "harfbuzz-#{version}"
+
+license path: 'COPYING'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/httpd.rb
+++ b/config/software/httpd.rb
@@ -12,14 +12,16 @@ version '2.4.12' do
   source md5: 'b8dc8367a57a8d548a9b4ce16d264a13'
 end
 
-relative_path "httpd-#{version}"
-
 dependency 'apr'
 dependency 'apr-util'
 dependency 'openssl'
 dependency 'pcre'
 dependency 'zlib'
 dependency 'libxml2'
+
+relative_path "httpd-#{version}"
+
+license path: 'LICENSE'
 
 
 build do

--- a/config/software/libaio.rb
+++ b/config/software/libaio.rb
@@ -3,10 +3,17 @@ default_version '0.3.110'
 
 # Note: we are getting this from Debian, because we trust Debian as a source, but the package has nothing
 # Debian-specific about it.
-source url: "http://ftp.debian.org/debian/pool/main/liba/libaio/libaio_#{version}.orig.tar.gz",
-       md5: '2a35602e43778383e2f4907a4ca39ab8'
+source url: "http://ftp.debian.org/debian/pool/main/liba/libaio/libaio_#{version}.orig.tar.gz"
+
+
+version '0.3.110' do
+  source md5: '2a35602e43778383e2f4907a4ca39ab8'
+end
 
 relative_path "libaio-#{version}"
+
+license path: 'COPYING'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -15,27 +15,37 @@
 # limitations under the License.
 #
 
-name 'libzmq'
-default_version '4.0.5'
+name "libedit"
+default_version "20120601-3.0"
 
-dependency 'libuuid'
+dependency "ncurses"
 
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
-
-version '4.0.5' do
-  source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d'
+version "20120601-3.0" do
+  source md5: "e50f6a7afb4de00c81650f7b1a0f5aea"
 end
 
-relative_path "zeromq-#{version}"
+version "20130712-3.1" do
+  source md5: "0891336c697362727a1fa7e60c5cb96c"
+end
 
-license path: 'COPYING.LESSER'
+source url: "http://www.thrysoee.dk/editline/libedit-#{version}.tar.gz"
+
+relative_path "libedit-#{version}"
+
+license path: 'COPYING'
 
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['CXXFLAGS'] = "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 
-  command "./configure --prefix=#{install_dir}/embedded", env: env
+  # The patch is from the FreeBSD ports tree and is for GCC compatibility.
+  # http://svnweb.freebsd.org/ports/head/devel/libedit/files/patch-vi.c?annotate=300896
+  if freebsd?
+    patch source: "freebsd-vi-fix.patch"
+  end
+
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env

--- a/config/software/libevent.rb
+++ b/config/software/libevent.rb
@@ -11,6 +11,8 @@ dependency 'openssl'
 
 relative_path "libevent-#{version}"
 
+license path: 'LICENSE'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -23,6 +23,9 @@ source url: "ftp://sourceware.org/pub/libffi/libffi-#{version}.tar.gz",
 
 relative_path "libffi-#{version}"
 
+license path: 'LICENSE'
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/libgcrypt.rb
+++ b/config/software/libgcrypt.rb
@@ -11,9 +11,13 @@ version '1.6.3' do
   source md5: '4262c3aadf837500756c2051a5c4ae5e'
 end
 
+dependency 'libgpg-error'
+
 relative_path "libgcrypt-#{version}"
 
-dependency 'libgpg-error'
+# TODO - There is a secondary license in 'LICENSES'
+license path: 'COPYING.LIB'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libgpg-error.rb
+++ b/config/software/libgpg-error.rb
@@ -13,6 +13,9 @@ end
 
 relative_path "libgpg-error-#{version}"
 
+license path: 'COPYING.LIB'
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -1,0 +1,53 @@
+#
+# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2015 Scalr, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "libiconv"
+default_version "1.14"
+
+dependency "patch" if solaris2?
+
+source url: "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz"
+
+version '1.14' do
+  source md5: 'e34509b1623cec449dfeb73d7ce9c6c6'
+end
+
+relative_path "libiconv-#{version}"
+
+license path: 'COPYING.LIB'
+
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  configure_command = "./configure" \
+                      " --prefix=#{install_dir}/embedded"
+  if aix?
+    patch_env = env.dup
+    patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}"
+    patch source: 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch', env: patch_env
+  else
+    patch source: 'libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch'
+  end
+
+  command configure_command, env: env
+
+  make "-j #{workers}", env: env
+  make "-j #{workers} install-lib" \
+          " libdir=#{install_dir}/embedded/lib" \
+          " includedir=#{install_dir}/embedded/include", env: env
+end

--- a/config/software/libldap.rb
+++ b/config/software/libldap.rb
@@ -1,13 +1,19 @@
 name 'libldap'
 default_version '2.4.40'
 
-source url: "http://ftp.debian.org/debian/pool/main/o/openldap/openldap_#{version}.orig.tar.gz",
-       md5: '03a8658e62131c0cdbf85dd604e498db'
+source url: "http://ftp.debian.org/debian/pool/main/o/openldap/openldap_#{version}.orig.tar.gz"
 
-relative_path "openldap_#{version}.orig"
+version '2.4.40' do
+  source md5: '03a8658e62131c0cdbf85dd604e498db'
+end
 
 dependency 'openssl'
 dependency 'libsasl'
+
+relative_path "openldap_#{version}.orig"
+
+license path: 'LICENSE'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -1,6 +1,6 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
-# Copyright 2015 Scalr, Inc.
+# Copyright 2014 Chef Software, Inc.
+# Copyright Scalr, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,28 +15,24 @@
 # limitations under the License.
 #
 
-name 'libzmq'
-default_version '4.0.5'
+name "liblzma"
+default_version "5.0.5"
 
-dependency 'libuuid'
+source url: "http://tukaani.org/xz/xz-#{version}.tar.gz",
+       md5: "19d924e066b6fff0bc9d1981b4e53196"
 
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
+relative_path "xz-#{version}"
 
-version '4.0.5' do
-  source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d'
-end
-
-relative_path "zeromq-#{version}"
-
-license path: 'COPYING.LESSER'
+license path: 'COPYING'  # TODO Other files included
 
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['CXXFLAGS'] = "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 
-  command "./configure --prefix=#{install_dir}/embedded", env: env
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded" \
+          " --disable-debug" \
+          " --disable-dependency-tracking", env: env
 
-  make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  make "install", env: env
 end

--- a/config/software/libmcrypt.rb
+++ b/config/software/libmcrypt.rb
@@ -3,10 +3,17 @@ default_version '2.5.8'
 
 # Note: we are getting this from Debian, because we trust Debian as a source, but the package has nothing
 # Debian-specific about it.
-source url: "http://ftp.debian.org/debian/pool/main/libm/libmcrypt/libmcrypt_#{version}.orig.tar.gz",
-       md5: '0821830d930a86a5c69110837c55b7da'
+source url: "http://ftp.debian.org/debian/pool/main/libm/libmcrypt/libmcrypt_#{version}.orig.tar.gz"
+
+
+version '2.5.8' do
+  source md5: '0821830d930a86a5c69110837c55b7da'
+end
 
 relative_path "libmcrypt-#{version}"
+
+license path: 'COPYING.LIB'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libmemcached.rb
+++ b/config/software/libmemcached.rb
@@ -7,9 +7,11 @@ version '1.0.18' do
   source md5: 'b3958716b4e53ddc5992e6c49d97e819'
 end
 
+dependency 'memcached'
+
 relative_path "libmemcached-#{version}"
 
-dependency 'memcached'
+license path: 'COPYING'
 
 
 build do

--- a/config/software/libpng.rb
+++ b/config/software/libpng.rb
@@ -15,28 +15,33 @@
 # limitations under the License.
 #
 
-name 'libzmq'
-default_version '4.0.5'
+name "libpng"
+default_version "1.5.17"
 
-dependency 'libuuid'
+source url: "http://downloads.sourceforge.net/libpng/libpng-#{version}.tar.gz"
 
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
-
-version '4.0.5' do
-  source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d'
+version "1.5.17" do
+  source md5: "d2e27dbd8c6579d1582b3f128fd284b4"
 end
 
-relative_path "zeromq-#{version}"
+version "1.5.13" do
+  source md5: "9c5a584d4eb5fe40d0f1bc2090112c65"
+end
 
-license path: 'COPYING.LESSER'
+dependency "zlib"
+
+relative_path "libpng-#{version}"
+
+license path: 'LICENSE'
 
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['CXXFLAGS'] = "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 
-  command "./configure --prefix=#{install_dir}/embedded", env: env
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded" \
+          " --with-zlib-prefix=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  make "install", env: env
 end

--- a/config/software/libsasl.rb
+++ b/config/software/libsasl.rb
@@ -7,10 +7,12 @@ version '2.1.26' do
   source md5: '45fc09469ca059df56d64acfe06a940d'
 end
 
-relative_path "cyrus-sasl-#{version}"
-
 dependency 'gdbm'
 dependency 'openssl'
+
+relative_path "cyrus-sasl-#{version}"
+
+license path: 'COPYING'
 
 
 build do

--- a/config/software/libssh2.rb
+++ b/config/software/libssh2.rb
@@ -1,14 +1,19 @@
 name 'libssh2'
 default_version '1.4.3'
 
-source url: "http://www.libssh2.org/download/libssh2-#{version}.tar.gz",
-       md5: '071004c60c5d6f90354ad1b701013a0b'
+source url: "http://www.libssh2.org/download/libssh2-#{version}.tar.gz"
 
-relative_path "libssh2-#{version}"
+version '1.4.3' do
+  source md5: '071004c60c5d6f90354ad1b701013a0b'
+end
 
 dependency 'zlib'
 dependency 'openssl'
 dependency 'libgcrypt'
+
+relative_path "libssh2-#{version}"
+
+license path: 'COPYING'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libuuid.rb
+++ b/config/software/libuuid.rb
@@ -15,28 +15,26 @@
 # limitations under the License.
 #
 
-name 'libzmq'
-default_version '4.0.5'
+name "libuuid"
+default_version "2.21"
 
-dependency 'libuuid'
+# We use the version in util-linux, and only build the libuuid subdirectory
+source url: "ftp://ftp.kernel.org/pub/linux/utils/util-linux/v#{version}/util-linux-#{version}.tar.gz"
 
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
-
-version '4.0.5' do
-  source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d'
+version '2.21' do
+  source md5: "4222aa8c2a1b78889e959a4722f1881a"
 end
 
-relative_path "zeromq-#{version}"
+relative_path "util-linux-#{version}"
 
-license path: 'COPYING.LESSER'
+license path: 'COPYING'
 
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['CXXFLAGS'] = "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 
   command "./configure --prefix=#{install_dir}/embedded", env: env
 
-  make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  make "-j #{workers}", env: env, cwd: "#{project_dir}/libuuid"
+  make "-j #{workers} install", env: env, cwd: "#{project_dir}/libuuid"
 end

--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -15,28 +15,37 @@
 # limitations under the License.
 #
 
-name 'libzmq'
-default_version '4.0.5'
+name "libxml2"
+default_version "2.9.1"
 
-dependency 'libuuid'
+source url: "ftp://xmlsoft.org/libxml2/libxml2-#{version}.tar.gz"
 
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
-
-version '4.0.5' do
-  source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d'
+version "2.7.8" do
+  source md5: "8127a65e8c3b08856093099b52599c86"
 end
 
-relative_path "zeromq-#{version}"
+version "2.9.1" do
+  source md5: "9c0cfef285d5c4a5c80d00904ddab380"
+end
 
-license path: 'COPYING.LESSER'
+dependency "zlib"
+dependency "libiconv"
+dependency "liblzma"
 
+relative_path "libxml2-#{version}"
+
+license path: 'COPYING'
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['CXXFLAGS'] = "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 
-  command "./configure --prefix=#{install_dir}/embedded", env: env
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded" \
+          " --with-zlib=#{install_dir}/embedded" \
+          " --with-iconv=#{install_dir}/embedded" \
+          " --without-python" \
+          " --without-icu", env: env
 
   make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  make "install", env: env
 end

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -18,16 +18,19 @@
 name 'libxslt'
 default_version '1.1.28'
 
-dependency 'libxml2'
-dependency 'liblzma'
+source url: "ftp://xmlsoft.org/libxml2/libxslt-#{version}.tar.gz"
 
 version '1.1.28' do
   source md5: '9667bf6f9310b957254fdcf6596600b7'
 end
 
-source url: "ftp://xmlsoft.org/libxml2/libxslt-#{version}.tar.gz"
+dependency 'libxml2'
+dependency 'liblzma'
 
 relative_path "libxslt-#{version}"
+
+license path: 'COPYING'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -1,6 +1,6 @@
 #
 # Copyright 2012-2014 Chef Software, Inc.
-# Copyright 2015 Scalr, Inc.
+# Copyright Scalr, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -15,27 +15,24 @@
 # limitations under the License.
 #
 
-name 'libzmq'
-default_version '4.0.5'
+name "libyaml"
+default_version '0.1.6'
 
-dependency 'libuuid'
+source url: "http://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz"
 
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
-
-version '4.0.5' do
-  source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d'
+version '0.1.6' do
+  source md5: '5fe00cda18ca5daeb43762b80c38e06e'
 end
 
-relative_path "zeromq-#{version}"
+relative_path "yaml-#{version}"
 
-license path: 'COPYING.LESSER'
+license path: 'LICENSE'
 
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['CXXFLAGS'] = "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 
-  command "./configure --prefix=#{install_dir}/embedded", env: env
+  command "./configure --prefix=#{install_dir}/embedded --enable-shared", env: env
 
   make "-j #{workers}", env: env
   make "-j #{workers} install", env: env

--- a/config/software/license-gem.rb
+++ b/config/software/license-gem.rb
@@ -1,0 +1,15 @@
+name 'license-gem'
+default_version '0.1.2'
+
+dependency 'ruby'
+dependency 'rubygems'
+
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  gem 'install gem-licenses' \
+      " --version '#{version}'" \
+      " --bindir '#{install_dir}/embedded/bin'" \
+      ' --no-ri --no-rdoc', env: env
+end

--- a/config/software/license-gem.rb
+++ b/config/software/license-gem.rb
@@ -1,3 +1,21 @@
+#
+# Copyright 2015 Scalr, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# NOLICENSE (Includes itself in the ruby license report)
+
 name 'license-gem'
 default_version '0.1.2'
 

--- a/config/software/memcached.rb
+++ b/config/software/memcached.rb
@@ -12,6 +12,8 @@ dependency 'libevent'
 
 relative_path "memcached-#{version}"
 
+license path: 'COPYING'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/mysql-gem.rb
+++ b/config/software/mysql-gem.rb
@@ -4,6 +4,9 @@ default_version '2.9.1'
 dependency 'ruby'
 dependency 'rubygems'
 
+license url: "https://raw.githubusercontent.com/luislavena/mysql-gem/v#{version.gsub('.', '_')}/COPYING"
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/mysql-utilities.rb
+++ b/config/software/mysql-utilities.rb
@@ -7,9 +7,11 @@ version '1.5.3' do
   source md5: 'e93ff4acf6a8b64b09af86a4829d0d6b'
 end
 
+dependency 'python'
+
 relative_path "mysql-utilities-#{version}"
 
-dependency 'python'
+license path: 'LICENSE.txt'
 
 
 build do

--- a/config/software/mysql.rb
+++ b/config/software/mysql.rb
@@ -3,14 +3,6 @@
 name 'mysql'
 default_version '5.6.24'
 
-dependency 'zlib'
-dependency 'ncurses'
-dependency 'libedit'
-dependency 'openssl'
-dependency 'libaio'
-dependency 'perl'
-
-
 source :url => "http://dev.mysql.com/get/Downloads/MySQL-5.6/mysql-#{version}.tar.gz"
 
 version '5.6.22' do
@@ -21,7 +13,16 @@ version '5.6.24' do
   source :md5 => '68e1911f70eb1b02170d4f96bf0f0f88'
 end
 
+dependency 'zlib'
+dependency 'ncurses'
+dependency 'libedit'
+dependency 'openssl'
+dependency 'libaio'
+dependency 'perl'
+
 relative_path "mysql-#{version}"
+
+license path: 'COPYING'
 
 
 # View: http://dev.mysql.com/doc/refman/5.5/en/source-configuration-options.html

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -23,6 +23,8 @@ source url: "http://ftp.gnu.org/gnu/ncurses/ncurses-#{version}.tar.gz",
 
 relative_path "ncurses-#{version}"
 
+license path: 'AUTHORS'
+
 ########################################################################
 #
 # wide-character support:

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -37,6 +37,9 @@ end
 
 relative_path "openssl-#{version}"
 
+license path: 'LICENSE'
+
+
 build do
   # View: https://raw.githubusercontent.com/opscode/omnibus-software/master/config/software/openssl.rb
   # We are only interested in Linux here.

--- a/config/software/pango.rb
+++ b/config/software/pango.rb
@@ -1,16 +1,20 @@
 name 'pango'
 default_version '1.36.8'
 
-source url: "http://ftp.gnome.org/pub/GNOME/sources/pango/1.36/pango-#{version}.tar.xz",
-       md5: '217a9a753006275215fa9fa127760ece'
+source url: "http://ftp.gnome.org/pub/GNOME/sources/pango/1.36/pango-#{version}.tar.xz"
 
-relative_path "pango-#{version}"
-
+version '1.36.8' do
+  source md5: '217a9a753006275215fa9fa127760ece'
+end
 
 dependency 'glib'
 dependency 'freetype'
 dependency 'fontconfig'
 dependency 'harfbuzz'
+
+relative_path "pango-#{version}"
+
+license path: 'COPYING'
 
 
 build do

--- a/config/software/pcre.rb
+++ b/config/software/pcre.rb
@@ -15,28 +15,30 @@
 # limitations under the License.
 #
 
-name 'libzmq'
-default_version '4.0.5'
+name "pcre"
+default_version "8.31"
 
-dependency 'libuuid'
+source url: "http://iweb.dl.sourceforge.net/project/pcre/pcre/#{version}/pcre-#{version}.tar.gz"
 
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
-
-version '4.0.5' do
-  source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d'
+version '8.31' do
+  source md5: "fab1bb3b91a4c35398263a5c1e0858c1"
 end
 
-relative_path "zeromq-#{version}"
+dependency "libedit"
+dependency "ncurses"
 
-license path: 'COPYING.LESSER'
+relative_path "pcre-#{version}"
+
+license path: 'LICENCE'
 
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['CXXFLAGS'] = "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 
-  command "./configure --prefix=#{install_dir}/embedded", env: env
+  command "./configure" \
+          " --prefix=#{install_dir}/embedded" \
+          " --enable-pcretest-libedit", env: env
 
   make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  make "install", env: env
 end

--- a/config/software/perl.rb
+++ b/config/software/perl.rb
@@ -30,6 +30,9 @@ end
 
 relative_path "perl-#{version}"
 
+license path: 'Copying'
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
   env['BUILD_ZLIB'] = "False"

--- a/config/software/php-memcached.rb
+++ b/config/software/php-memcached.rb
@@ -7,11 +7,14 @@ version '2.2.0' do
   source md5: '28937c6144f734e000c6300242f44ce6'
 end
 
-relative_path "memcached-#{version}"
-
 dependency 'zlib'
 dependency 'libmemcached'
 dependency 'php'
+
+
+relative_path "memcached-#{version}"
+
+license path: 'LICENSE'
 
 
 build do

--- a/config/software/php-pecl_http.rb
+++ b/config/software/php-pecl_http.rb
@@ -1,15 +1,20 @@
 name 'php-pecl_hhtp'
 default_version '1.7.6'
 
-source url: "http://pecl.php.net/get/pecl_http-#{version}.tgz",
-       md5: '4926c17a24a11a9b1cf3ec613fad97cb'
+source url: "http://pecl.php.net/get/pecl_http-#{version}.tgz"
 
-relative_path "pecl_http-#{version}"
+version '1.7.6' do
+  source md5: '4926c17a24a11a9b1cf3ec613fad97cb'
+end
 
 dependency 'zlib'
 dependency 'curl'
 dependency 'file'  # libmagic
 dependency 'php'
+
+relative_path "pecl_http-#{version}"
+
+license path: 'LICENSE'
 
 
 build do

--- a/config/software/php-rrd.rb
+++ b/config/software/php-rrd.rb
@@ -1,13 +1,18 @@
 name 'php-rrd'
 default_version '1.1.3'
 
-source url: "http://pecl.php.net/get/rrd-#{version}.tgz",
-       md5: 'bde6c50fa2aa39090ed22e574ac71c5a'
+source url: "http://pecl.php.net/get/rrd-#{version}.tgz"
 
-relative_path "rrd-#{version}"
+version '1.1.3' do
+  source md5: 'bde6c50fa2aa39090ed22e574ac71c5a'
+end
 
 dependency 'rrdtool'
 dependency 'php'
+
+relative_path "rrd-#{version}"
+
+license path: 'LICENSE'
 
 
 build do

--- a/config/software/php-ssh2.rb
+++ b/config/software/php-ssh2.rb
@@ -9,6 +9,7 @@ relative_path "ssh2-#{version}"
 dependency 'libssh2'
 dependency 'php'
 
+license path: 'LICENSE'
 
 build do
        env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/php-yaml.rb
+++ b/config/software/php-yaml.rb
@@ -9,6 +9,8 @@ relative_path "yaml-#{version}"
 dependency 'libyaml'
 dependency 'php'
 
+license path: 'LICENSE'
+
 
 build do
        env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/php-zmq.rb
+++ b/config/software/php-zmq.rb
@@ -9,6 +9,8 @@ relative_path "zmq-#{version}"
 dependency 'libzmq'
 dependency 'php'
 
+license path: 'LICENSE'
+
 
 build do
        env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/php.rb
+++ b/config/software/php.rb
@@ -53,6 +53,8 @@ end
 
 relative_path "php-#{version}"
 
+license path: 'LICENSE'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/pip.rb
+++ b/config/software/pip.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2013-2014 Chef Software, Inc.
 # Copyright 2015 Scalr, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,28 +15,26 @@
 # limitations under the License.
 #
 
-name 'libzmq'
-default_version '4.0.5'
+name "pip"
+default_version "1.3"
 
-dependency 'libuuid'
+dependency "setuptools"
 
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
+source url: "https://pypi.python.org/packages/source/p/pip/pip-#{version}.tar.gz"
 
-version '4.0.5' do
-  source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d'
+
+version '1.3' do
+  source md5: '918559b784e2aca9559d498050bb86e7'
 end
 
-relative_path "zeromq-#{version}"
+relative_path "pip-#{version}"
 
-license path: 'COPYING.LESSER'
+license path: 'LICENSE.txt'
 
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['CXXFLAGS'] = "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 
-  command "./configure --prefix=#{install_dir}/embedded", env: env
-
-  make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  command "#{install_dir}/embedded/bin/python setup.py install" \
+          " --prefix=#{install_dir}/embedded", env: env
 end

--- a/config/software/pixman.rb
+++ b/config/software/pixman.rb
@@ -1,10 +1,16 @@
 name 'pixman'
 default_version '0.32.6'
 
-source url: "http://cairographics.org/releases/pixman-#{version}.tar.gz",
-       md5: '3a30859719a41bd0f5cccffbfefdd4c2'
+source url: "http://cairographics.org/releases/pixman-#{version}.tar.gz"
+
+version '0.32.6' do
+  source md5: '3a30859719a41bd0f5cccffbfefdd4c2'
+end
 
 relative_path "pixman-#{version}"
+
+license path: 'COPYING'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/prepare.rb
+++ b/config/software/prepare.rb
@@ -15,6 +15,8 @@
 # limitations under the License.
 #
 
+# NOLICENSE (Nothing included in package)
+
 name 'prepare'
 description 'the steps required to prepare the build'
 default_version '1.0.0'

--- a/config/software/putty.rb
+++ b/config/software/putty.rb
@@ -13,6 +13,9 @@ end
 
 relative_path "putty-#{version}"
 
+license path: 'LICENCE'
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/python-m2crypto.rb
+++ b/config/software/python-m2crypto.rb
@@ -4,10 +4,13 @@ default_version '0.22.3'
 source url: "https://pypi.python.org/packages/source/M/M2Crypto/M2Crypto-#{version}.tar.gz",
        md5: '573f21aaac7d5c9549798e72ffcefedd'
 
-relative_path "M2Crypto-#{version}"
-
 dependency 'python'
 dependency 'openssl'
+
+
+relative_path "M2Crypto-#{version}"
+
+license url: 'https://raw.githubusercontent.com/M2Crypto/M2Crypto/master/LICENCE'
 
 
 build do

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -40,6 +40,9 @@ end
 
 relative_path "Python-#{version}"
 
+license path: 'LICENSE'
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
   env['CFLAGS'] = "-I#{install_dir}/embedded/include -O3 -g -pipe"

--- a/config/software/rrdtool.rb
+++ b/config/software/rrdtool.rb
@@ -1,10 +1,11 @@
 name 'rrdtool'
 default_version '1.4.9'
 
-source url: "http://oss.oetiker.ch/rrdtool/pub/rrdtool-#{version}.tar.gz",
-       md5: '1cea5a9efd6a48ac4035b0f9c7e336cf'
+source url: "http://oss.oetiker.ch/rrdtool/pub/rrdtool-#{version}.tar.gz"
 
-relative_path "rrdtool-#{version}"
+version '1.4.9' do
+  source md5: '1cea5a9efd6a48ac4035b0f9c7e336cf'
+end
 
 dependency 'zlib'
 dependency 'libpng'
@@ -15,6 +16,11 @@ dependency 'pixman'
 dependency 'cairo'
 dependency 'glib'
 dependency 'pango'
+
+relative_path "rrdtool-#{version}"
+
+# TODO There is another one for the libs
+license path: 'COPYING'
 
 
 build do

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -1,0 +1,179 @@
+#
+# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2015 Scalr, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "ruby"
+default_version "1.9.3-p550"
+
+dependency "zlib"
+dependency "ncurses"
+dependency "libedit"
+dependency "openssl"
+dependency "libyaml"
+dependency "libiconv"
+dependency "libffi"
+dependency "gdbm"
+dependency "patch" if solaris2?
+
+version("1.9.3-p484") { source md5: "8ac0dee72fe12d75c8b2d0ef5d0c2968" }
+version("1.9.3-p547") { source md5: "7531f9b1b35b16f3eb3d7bea786babfd" }
+version("1.9.3-p550") { source md5: "e05135be8f109b2845229c4f47f980fd" }
+version("2.0.0-p576") { source md5: "2e1f4355981b754d92f7e2cc456f843d" }
+version("2.0.0-p594") { source md5: "a9caa406da5d72f190e28344e747ee74" }
+version("2.0.0-p645") { source md5: "49919bba0c855eaf8e247108c7933a62" }
+version("2.1.1")      { source md5: "e57fdbb8ed56e70c43f39c79da1654b2" }
+version("2.1.2")      { source md5: "a5b5c83565f8bd954ee522bd287d2ca1" }
+version("2.1.3")      { source md5: "74a37b9ad90e4ea63c0eed32b9d5b18f" }
+version("2.1.4")      { source md5: "89b2f4a197621346f6724a3c35535b19" }
+version("2.1.5")      { source md5: "df4c1b23f624a50513c7a78cb51a13dc" }
+version("2.1.6")      { source md5: "6e5564364be085c45576787b48eeb75f" }
+
+source url: "http://cache.ruby-lang.org/pub/ruby/#{version.match(/^(\d+\.\d+)/)[0]}/ruby-#{version}.tar.gz"
+
+relative_path "ruby-#{version}"
+
+license path: 'COPYING'
+
+
+env = with_standard_compiler_flags(with_embedded_path)
+
+case ohai['platform']
+when "mac_os_x"
+  # -Qunused-arguments suppresses "argument unused during compilation"
+  # warnings. These can be produced if you compile a program that doesn't
+  # link to anything in a path given with -Lextra-libs. Normally these
+  # would be harmless, except that autoconf treats any output to stderr as
+  # a failure when it makes a test program to check your CFLAGS (regardless
+  # of the actual exit code from the compiler).
+  env['CFLAGS'] << " -I#{install_dir}/embedded/include/ncurses -arch x86_64 -m64 -O3 -g -pipe -Qunused-arguments"
+  env['LDFLAGS'] << " -arch x86_64"
+when "freebsd"
+  # Stops "libtinfo.so.5.9: could not read symbols: Bad value" error when
+  # compiling ext/readline. See the following for more info:
+  #
+  #   https://lists.freebsd.org/pipermail/freebsd-current/2013-October/045425.html
+  #   http://mailing.freebsd.ports-bugs.narkive.com/kCgK8sNQ/ports-183106-patch-sysutils-libcdio-does-not-build-on-10-0-and-head
+  #
+  env['LDFLAGS'] << " -ltinfow"
+when "aix"
+  # this magic per IBM
+  env['LDSHARED'] = "xlc -G"
+  env['CFLAGS'] = "-I#{install_dir}/embedded/include/ncurses -I#{install_dir}/embedded/include"
+  # this magic per IBM
+  env['XCFLAGS'] = "-DRUBY_EXPORT"
+  # need CPPFLAGS set so ruby doesn't try to be too clever
+  env['CPPFLAGS'] = "-I#{install_dir}/embedded/include/ncurses -I#{install_dir}/embedded/include"
+  env['SOLIBS'] = "-lm -lc"
+  # need to use GNU m4, default m4 doesn't work
+  env['M4'] = "/opt/freeware/bin/m4"
+when "solaris2"
+  if ohai['kernel']['machine'].include?('sun4')
+    # Known issue with rubby where too much GCC optimization blows up miniruby on sparc
+    env['CFLAGS'] << " -std=c99 -O0 -g -pipe -mcpu=v9"
+    env['LDFLAGS'] << " -mcpu=v9"
+  else
+    env['CFLAGS'] << " -std=c99 -O3 -g -pipe"
+  end
+else  # including linux
+  env['CFLAGS'] << " -O3 -g -pipe"
+end
+
+build do
+  if solaris2? && version.to_f >= 2.1
+    patch source: "ruby-solaris-no-stack-protector.patch", plevel: 1
+    if ohai['platform_version'].to_f >= 5.11
+      patch source: "ruby-solaris-linux-socket-compat.patch", plevel: 1
+    end
+  elsif solaris2? && version =~ /^1.9/
+    patch source: "ruby-sparc-1.9.3-c99.patch", plevel: 1
+  end
+
+  # AIX needs /opt/freeware/bin only for patch
+  patch_env = env.dup
+  patch_env['PATH'] = "/opt/freeware/bin:#{env['PATH']}" if aix?
+
+  # disable libpath in mkmf across all platforms, it trolls omnibus and
+  # breaks the postgresql cookbook.  i'm not sure why ruby authors decided
+  # this was a good idea, but it breaks our use case hard.  AIX cannot even
+  # compile without removing it, and it breaks some native gem installs on
+  # other platforms.  generally you need to have a condition where the
+  # embedded and non-embedded libs get into a fight (libiconv, openssl, etc)
+  # and ruby trying to set LD_LIBRARY_PATH itself gets it wrong.
+  if version.to_f >= 2.1
+    patch source: "ruby_aix_2_1_3_mkmf.patch", plevel: 1, env: patch_env
+    # should intentionally break and fail to apply on 2.2, patch will need to
+    # be fixed.
+  end
+
+  configure_command = ["./configure",
+                       "--prefix=#{install_dir}/embedded",
+                       "--with-out-ext=dbm",
+                       "--enable-shared",
+                       "--enable-libedit",
+                       "--with-ext=psych",
+                       "--disable-install-doc",
+                       "--without-gmp",
+                       "--disable-dtrace"]
+
+  case ohai['platform']
+  when "aix"
+    # need to patch ruby's configure file so it knows how to find shared libraries
+    patch source: "ruby-aix-configure.patch", plevel: 1, env: patch_env
+    # have ruby use zlib on AIX correctly
+    patch source: "ruby_aix_openssl.patch", plevel: 1, env: patch_env
+    # AIX has issues with ssl retries, need to patch to have it retry
+    patch source: "ruby_aix_2_1_3_ssl_EAGAIN.patch", plevel: 1, env: patch_env
+    # the next two patches are because xlc doesn't deal with long vs int types well
+    patch source: "ruby-aix-atomic.patch", plevel: 1, env: patch_env
+    patch source: "ruby-aix-vm-core.patch", plevel: 1, env: patch_env
+
+    # per IBM, just help ruby along on what it's running on
+    configure_command << "--host=powerpc-ibm-aix6.1.0.0 --target=powerpc-ibm-aix6.1.0.0 --build=powerpc-ibm-aix6.1.0.0 --enable-pthread"
+
+  when "freebsd"
+    # Disable optional support C level backtrace support. This requires the
+    # optional devel/libexecinfo port to be installed.
+    configure_command << "ac_cv_header_execinfo_h=no"
+    configure_command << "--with-opt-dir=#{install_dir}/embedded"
+  when "smartos"
+    # Opscode patch - someara@opscode.com
+    # GCC 4.7.0 chokes on mismatched function types between OpenSSL 1.0.1c and Ruby 1.9.3-p286
+    patch source: "ruby-openssl-1.0.1c.patch", plevel: 1
+
+    # Patches taken from RVM.
+    # http://bugs.ruby-lang.org/issues/5384
+    # https://www.illumos.org/issues/1587
+    # https://github.com/wayneeseguin/rvm/issues/719
+    patch source: "rvm-cflags.patch", plevel: 1
+
+    # From RVM forum
+    # https://github.com/wayneeseguin/rvm/commit/86766534fcc26f4582f23842a4d3789707ce6b96
+    configure_command << "ac_cv_func_dl_iterate_phdr=no"
+    configure_command << "--with-opt-dir=#{install_dir}/embedded"
+  else
+    configure_command << "--with-opt-dir=#{install_dir}/embedded"
+  end
+
+  # FFS: works around a bug that infects AIX when it picks up our pkg-config
+  # AFAIK, ruby does not need or use this pkg-config it just causes the build to fail.
+  # The alternative would be to patch configure to remove all the pkg-config garbage entirely
+  env.merge!("PKG_CONFIG" => "/bin/true") if aix?
+
+  command configure_command.join(" "), env: env
+  make "-j #{workers}", env: env
+  make "-j #{workers} install", env: env
+
+end

--- a/config/software/rubygems.rb
+++ b/config/software/rubygems.rb
@@ -1,0 +1,78 @@
+#
+# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2015 Scalr, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "rubygems"
+default_version "1.8.24"
+
+if windows?
+  dependency "ruby-windows"
+  dependency "ruby-windows-devkit"
+else
+  dependency "ruby"
+end
+
+unless windows?
+  version "1.8.29" do
+    source md5: "a57fec0af33e2e2e1dbb3a68f6cc7269"
+  end
+
+  version "1.8.24" do
+    source md5: "3a555b9d579f6a1a1e110628f5110c6b"
+  end
+
+  # NOTE: this is the last version of rubygems before the 2.2.x change to native gem install location
+  #
+  #  https://github.com/rubygems/rubygems/issues/874
+  #
+  # This is a breaking change for omnibus clients.  Chef-11 needs to be pinned to 2.1.11 for eternity.
+  version "2.1.11" do
+    source md5: "b561b7aaa70d387e230688066e46e448"
+  end
+
+  version "2.2.1" do
+    source md5: "1f0017af0ad3d3ed52665132f80e7443"
+  end
+
+  version "2.4.1" do
+    source md5: "7e39c31806bbf9268296d03bd97ce718"
+  end
+
+  version "2.4.4" do
+    source md5: "440a89ad6a3b1b7a69b034233cc4658e"
+  end
+
+  version "2.4.5" do
+    source md5: "5918319a439c33ac75fbbad7fd60749d"
+  end
+
+  source url: "http://production.cf.rubygems.org/rubygems/rubygems-#{version}.tgz"
+end
+
+relative_path "rubygems-#{version}"
+
+license path: 'LICENSE.txt'
+
+
+build do
+  env = with_embedded_path
+
+  if windows?
+    command "gem update --system #{version} --no-ri --no-rdoc", env: env
+  else
+    ruby "setup.rb --no-ri --no-rdoc", env: env
+  end
+end

--- a/config/software/safe_yaml-gem.rb
+++ b/config/software/safe_yaml-gem.rb
@@ -5,6 +5,8 @@ dependency 'ruby'
 dependency 'rubygems'
 dependency 'libyaml'
 
+license url: "https://raw.githubusercontent.com/dtao/safe_yaml/#{version}/LICENSE.txt"
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/scalr-app-php-libs.rb
+++ b/config/software/scalr-app-php-libs.rb
@@ -1,3 +1,21 @@
+#
+# Copyright 2015 Scalr, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# NOLICENSE (Nothing gets included in the package)
+
 name 'scalr-app-php-libs'
 
 dependency 'php-memcached'

--- a/config/software/scalr-app-python-libs.rb
+++ b/config/software/scalr-app-python-libs.rb
@@ -1,3 +1,21 @@
+#
+# Copyright 2015 Scalr, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# NOLICENSE (Nothing gets included in the package)
+
 name 'scalr-app-python-libs'
 
 source :path => '__SCALR_REQUIREMENTS_PATH__'

--- a/config/software/scalr-app.rb
+++ b/config/software/scalr-app.rb
@@ -3,6 +3,15 @@ default_version '__SCALR_APP_REVISION__'
 
 source :git => '__SCALR_APP_PATH__'
 
+[
+  ['adodb5', '18', 'license.txt'],
+  ['apache-log4php', '2.0.0-incubating', 'LICENSE'],
+  ['google-api-php-client', 'git-03102014', 'LICENSE'],
+  ['google-api-php-client', 'git-03162015', 'LICENSE'],
+].each do |dep_name, dep_version, dep_license|
+  license path: "app/src/externals/#{dep_name}-#{dep_version}/#{dep_license}", name: dep_name, version: dep_version
+end
+
 
 build do
   # Copy the code to the ./scalr dir.

--- a/config/software/scalr-server-bin.rb
+++ b/config/software/scalr-server-bin.rb
@@ -20,7 +20,9 @@
 
 name 'scalr-server-bin'
 
-source :path => File.expand_path('files/scalr-server-bin', Omnibus::Config.project_root)
+source path: File.expand_path('files/scalr-server-bin', Omnibus::Config.project_root)
+
+license path: 'LICENSE'
 
 build do
   # Shell commands imported from the repo

--- a/config/software/scalr-server-cookbooks.rb
+++ b/config/software/scalr-server-cookbooks.rb
@@ -20,7 +20,9 @@
 
 name 'scalr-server-cookbooks'
 
-source :path => File.expand_path('files/scalr-server-cookbooks', Omnibus::Config.project_root)
+source path: File.expand_path('files/scalr-server-cookbooks', Omnibus::Config.project_root)
+
+license path: 'LICENSE'
 
 berks_pkg = 'pkg.tar.gz'
 

--- a/config/software/sentry-raven-gem.rb
+++ b/config/software/sentry-raven-gem.rb
@@ -4,6 +4,9 @@ default_version '0.9.4'  # https://github.com/coderanger/chef-sentry-handler/blo
 dependency 'ruby'
 dependency 'rubygems'
 
+license url: "https://raw.githubusercontent.com/getsentry/raven-ruby/#{version}/LICENSE"
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -1,5 +1,5 @@
 #
-# Copyright 2012-2014 Chef Software, Inc.
+# Copyright 2013-2014 Chef Software, Inc.
 # Copyright 2015 Scalr, Inc.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,28 +15,24 @@
 # limitations under the License.
 #
 
-name 'libzmq'
-default_version '4.0.5'
+name "setuptools"
+default_version "0.7.7"
 
-dependency 'libuuid'
+dependency "python"
 
-source url: "http://download.zeromq.org/zeromq-#{version}.tar.gz"
+source url: "https://pypi.python.org/packages/source/s/setuptools/setuptools-#{version}.tar.gz"
 
-version '4.0.5' do
-  source md5: '73c39f5eb01b9d7eaf74a5d899f1d03d'
+version '0.7.7' do
+  source md5: '0d7bc0e1a34b70a97e706ef74aa7f37f'
+  license url: "https://bitbucket.org/pypa/setuptools/src/#{version}/setup.py?at=default#cl-138"
 end
 
-relative_path "zeromq-#{version}"
-
-license path: 'COPYING.LESSER'
+relative_path "setuptools-#{version}"
 
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)
-  env['CXXFLAGS'] = "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include"
 
-  command "./configure --prefix=#{install_dir}/embedded", env: env
-
-  make "-j #{workers}", env: env
-  make "-j #{workers} install", env: env
+  command "#{install_dir}/embedded/bin/python setup.py install" \
+          " --prefix=#{install_dir}/embedded", env: env
 end

--- a/config/software/sqlite.rb
+++ b/config/software/sqlite.rb
@@ -9,6 +9,8 @@ end
 
 relative_path "sqlite-autoconf-#{version}"
 
+license url: 'https://www.sqlite.org/copyright.html'
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/ssh-keygen.rb
+++ b/config/software/ssh-keygen.rb
@@ -28,6 +28,9 @@ end
 
 relative_path "openssh-#{version}"
 
+license path: 'LICENCE', encoding: Encoding::ISO_8859_1
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/config/software/ssmtp.rb
+++ b/config/software/ssmtp.rb
@@ -18,16 +18,19 @@ require 'shellwords'
 name 'ssmtp'
 default_version '2.64'
 
-dependency 'openssl'
-dependency 'cacerts'
-
 source url: "http://ftp.de.debian.org/debian/pool/main/s/ssmtp/ssmtp_#{version}.orig.tar.bz2"
 
 version '2.64' do
   source md5: '65b4e0df4934a6cd08c506cabcbe584f'
 end
 
+dependency 'openssl'
+dependency 'cacerts'
+
 relative_path "ssmtp-#{version}"
+
+license path: 'COPYING'
+
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/supervisor.rb
+++ b/config/software/supervisor.rb
@@ -2,9 +2,10 @@ name 'supervisor'
 description 'Process manager'
 default_version '3.1.3'
 
-
 dependency 'python'
 dependency 'pip'
+
+license url: "https://raw.githubusercontent.com/Supervisor/supervisor/#{version}/LICENSES.txt"
 
 
 build do

--- a/config/software/yolk.rb
+++ b/config/software/yolk.rb
@@ -1,3 +1,21 @@
+#
+# Copyright 2015 Scalr, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# NOLICENSE (Includes itself in the Python license report)
+
 name 'yolk'
 default_version '0.8.6'
 

--- a/config/software/yolk.rb
+++ b/config/software/yolk.rb
@@ -1,0 +1,11 @@
+name 'yolk'
+default_version '0.8.6'
+
+dependency 'python'
+dependency 'pip'
+
+
+build do
+  env = with_standard_compiler_flags(with_embedded_path)
+  command "#{install_dir}/embedded/bin/pip install yolk3k==#{version}", env: env
+end

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -26,6 +26,9 @@ source url: "http://downloads.sourceforge.net/project/libpng/zlib/#{version}/zli
 
 relative_path "zlib-#{version}"
 
+license path: 'README', cue: 'Copyright notice'
+
+
 build do
   env = with_standard_compiler_flags(with_embedded_path)
 

--- a/files/license-scripts/python-licenses.py
+++ b/files/license-scripts/python-licenses.py
@@ -1,0 +1,10 @@
+import sys
+from yolk import cli
+
+
+if __name__ == '__main__':
+    out = sys.argv[1]
+    sys.argv = [sys.argv[0], "-l", "-f", "license"]
+    with open(out, 'w') as f:
+        sys.stdout = f
+        cli.main()

--- a/files/license-scripts/ruby-licenses.rb
+++ b/files/license-scripts/ruby-licenses.rb
@@ -1,0 +1,23 @@
+require 'gem_licenses'
+
+
+# gem-licenses uses the gems that are loaded, so we just load all the gems.
+Gem::Specification.each do |gem|
+  begin
+    require gem.name
+  rescue LoadError
+    # ignored
+  end
+end
+
+File.open(ARGV.first, 'w') do |f|
+  Gem.licenses.each do |license, gems|
+    f.puts "#{license}"
+    f.puts '=' * license.length
+    gems.sort_by(&:name).each do |gem|
+      f.puts "* #{gem.name} #{gem.version} (#{gem.homepage})"
+    end
+    f.puts ''
+  end
+end
+

--- a/files/scalr-server-bin/LICENSE
+++ b/files/scalr-server-bin/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2015 Scalr, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/files/scalr-server-cookbooks/LICENSE
+++ b/files/scalr-server-cookbooks/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2015 Scalr, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Automatically generates license reports in `/opt/scalr-server/embedded/LICENSE`, for the libraries we build in Omnibus, as well as those we install (Python and Ruby).