### PR TITLE
Refactor timeout settings

### DIFF
--- a/files/scalr-server-cookbooks/scalr-server/attributes/default.rb
+++ b/files/scalr-server-cookbooks/scalr-server/attributes/default.rb
@@ -156,8 +156,15 @@ default[:scalr_server][:app][:memcached_port] = nil
 # Current configuration (allows multiple memcached servers)
 default[:scalr_server][:app][:memcached_servers] = ['127.0.0.1:6281']
 
-# PHP session cookie lifetime. You can extend or reduce this depending on your security requirements.
-default[:scalr_server][:app][:session_cookie_lifetime] = 1800
+# Deprecated
+default[:scalr_server][:app][:session_cookie_lifetime] = nil
+
+# The session_cookie_timeout controls the timeout on the session cookie, which will result in immediate logout of the user.
+# Note that session_cookie_timeout should not be relied on as a security measure (it is managed client-side).
+default[:scalr_server][:app][:session_cookie_timeout] = 0
+# The session_soft_timeout is an inactivity timeout. If the user is inactive during this period of time, they'll be logged out.
+# The session_soft_timeout can be relied on as a security measure, since it is managed server-side.
+default[:scalr_server][:app][:session_soft_timeout] = 1800
 
 # Hash of arbitrary configuration parameters to include in the Scalr configuration. This will be deeply merged
 # with the default configuration. Note that arrays are *not* deeply merged (so that you can remove values from their

--- a/files/scalr-server-cookbooks/scalr-server/libraries/service_helper.rb
+++ b/files/scalr-server-cookbooks/scalr-server/libraries/service_helper.rb
@@ -332,6 +332,24 @@ module Scalr
     end
 
 
+    ###############
+    # App Helpers #
+    ###############
+
+    # We renamed this setting to be consistent with the below. Use the old value if set, otherwise we use the new one.
+    # We have to use .nil? instead of || ... here, because the timeout may reasonable be 0.
+    def session_cookie_timeout(node)
+      unless node[:scalr_server][:app][:session_cookie_lifetime].nil?
+        return node[:scalr_server][:app][:session_cookie_lifetime]
+      end
+       node[:scalr_server][:app][:session_cookie_timeout]
+    end
+
+    def session_soft_timeout (node)
+      node[:scalr_server][:app][:session_soft_timeout]
+    end
+
+
     ####################
     # Endpoint helpers #
     ####################

--- a/files/scalr-server-cookbooks/scalr-server/spec/unit/service_helper_spec.rb
+++ b/files/scalr-server-cookbooks/scalr-server/spec/unit/service_helper_spec.rb
@@ -253,4 +253,32 @@ describe Scalr::ServiceHelper do
       expect(dummy_class.new.plotter_port(node)).to eq(8000)
     end
   end
+
+  describe '#session_cookie_timeout' do
+    it 'should use session_cookie_lifetime if set'  do
+      node.set[:scalr_server][:app][:session_cookie_lifetime] = 10
+      node.set[:scalr_server][:app][:session_cookie_timeout] = 20
+      expect(dummy_class.new.session_cookie_timeout(node)).to eq(10)
+    end
+
+    it 'should consider 0 to be set'  do
+      node.set[:scalr_server][:app][:session_cookie_lifetime] = 0
+      node.set[:scalr_server][:app][:session_cookie_timeout] = 20
+      expect(dummy_class.new.session_cookie_timeout(node)).to eq(0)
+    end
+
+    it 'should use session_cookie_timeout otherwise' do
+      node.set[:scalr_server][:app][:session_cookie_lifetime] = nil
+      node.set[:scalr_server][:app][:session_cookie_timeout] = 0
+      expect(dummy_class.new.session_cookie_timeout(node)).to eq(0)
+    end
+  end
+
+  describe '#session_soft_timeout' do
+    it 'should return the session soft timeout' do
+      node.set[:scalr_server][:app][:session_soft_timeout] = 10
+      expect(dummy_class.new.session_soft_timeout(node)).to eq(10)
+    end
+  end
+
 end

--- a/files/scalr-server-cookbooks/scalr-server/templates/default/app/php.ini.erb
+++ b/files/scalr-server-cookbooks/scalr-server/templates/default/app/php.ini.erb
@@ -1944,8 +1944,8 @@ report_memleaks = Off
 ; Scalr :: Sessions
 ; View: https://github.com/php-memcached-dev/php-memcached/issues/47
 
-session.cookie_lifetime = <%= node[:scalr_server][:app][:session_cookie_lifetime] %>
-session.gc_maxlifetime = <%= 2 * (1 + node[:scalr_server][:app][:session_cookie_lifetime]) %>
+session.cookie_lifetime = <%= session_cookie_timeout node %>
+session.gc_maxlifetime = <%= session_soft_timeout node %>
 
 session.save_handler = memcached
 session.save_path = <%= memcached_servers(node).join(', ') %>


### PR DESCRIPTION
+ Add `session_soft_timeout` to control the timeout on sessions in
Memcached. A.k.a. inactivity timeout.
+ Rename `session_cookie_lifetime` to session_cookie_timeout