### PR TITLE
Fix missing space in curl definition

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -59,7 +59,7 @@ build do
           ' --without-librtmp' \
           ' --without-libssh2' \
           " --with-ssl=#{install_dir}/embedded" \
-           "--with-zlib=#{install_dir}/embedded", env: env
+          " --with-zlib=#{install_dir}/embedded", env: env
 
   make "-j #{workers}", env: env
   make 'install', env: env


### PR DESCRIPTION
@buzzy We had pulled this in from Chef's Omnibus Software and I saw this PR go through in theirs. 

See: https://github.com/chef/omnibus-software/pull/445