### PR TITLE
Disable poller, possible typo

### DIFF
--- a/hack/docker/scalr-server-local.worker.rb
+++ b/hack/docker/scalr-server-local.worker.rb
@@ -2,4 +2,4 @@
 # Those two services are deployed on the stats server instead.
 cron[:enable] = true
 service[:enable] = true
-service[:disable] = ['plotter', 'plotter']
+service[:disable] = ['plotter', 'poller']


### PR DESCRIPTION
Looks like a typo which means the poller is not disabled on the worker. 