### PR TITLE
INST-78 : Update package process rewrites customer's Timezone to UTC until reconfigure

### DIFF
--- a/config/software/finalize.rb
+++ b/config/software/finalize.rb
@@ -50,6 +50,8 @@ build do
     command "rm -rf '#{install_dir}/embedded/#{dir}'"
   end
 
+  delete "#{install_dir}/etc/php"
+
   # Version Manifest
   block do
     File.open("#{install_dir}/version-manifest.txt", 'w') do |f|


### PR DESCRIPTION
Solution: Remove php.ini from package

This file is added in the php libs, apparently to make composer happy.
We need to remove it from the package so that it doesn't overwrite the
existing file on package installation