### PR TITLE
INST-81 : Lower minimum memory threshold

### DIFF
--- a/files/scalr-server-bin/scalr-server-ctl
+++ b/files/scalr-server-bin/scalr-server-ctl
@@ -35,7 +35,7 @@ config_test () {
 }
 
 memory_test () {
-    if [ "$(awk '/MemTotal/{print $2}' /proc/meminfo)" -lt 3700000 ]; then
+    if [ "$(awk '/MemTotal/{print $2}' /proc/meminfo)" -lt 3600000 ]; then
         echo "Scalr requires a minimum of 4GB RAM to run."
         exit 1
     fi


### PR DESCRIPTION
Apparently some t2.medium have less then 3.7GB (SES-78)